### PR TITLE
Fix formatting in welcome and round-off error chapters

### DIFF
--- a/Book/Chapters/Roundoff error/Finite precision representations.ipynb
+++ b/Book/Chapters/Roundoff error/Finite precision representations.ipynb
@@ -2,681 +2,431 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "wW4KU3zHwz10"
-   },
+   "metadata": {},
    "source": [
     "# Finite precision representations"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
-   "source": []
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "bYHF46lJ478J"
-   },
+   "metadata": {},
    "source": [
     "## Binary representation"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "wBgeKOkhx7kh"
-   },
+   "metadata": {},
    "source": [
-    "Humans use a base-10 numbering system called 'decimal', probably because that's how many fingers we (typically) have.  \n",
-    "\n",
-    "\n",
-    "\n",
-    "> Except for Mayans who used base-20: 'vegesimal' system! I guess they could only do math sitting down!\n",
-    "\n",
-    "The number 1305 is expressed in decimal with each column indicating a power of the base ($10$):\n",
-    "$1305_{10} = 5 \\times 10^0 + 0 \\times 10^1 + 3 \\times 10^2 + 1 \\times 10^3$\n",
-    "\n",
+    "Humans use a base-10 numbering system called 'decimal', probably because that's how many fingers we (typically) have.",
+    "> Except for Mayans who used base-20: 'vegesimal' system! I guess they could only do math sitting down!",
+    "The number 1305 is expressed in decimal with each column indicating a power of the base ($10$):",
+    "$1305_{10} = 5 \\times 10^0 + 0 \\times 10^1 + 3 \\times 10^2 + 1 \\times 10^3$",
     "NB: We wrote the order of digits backwards so we could go in increasing powers."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "au9vfgnu0lZq"
-   },
+   "metadata": {},
    "source": [
     "Computers use base 2 (binary) since a bit can only be 0 or 1. The same number is written as:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {
-    "id": "6n7Oeb2Fea6A"
-   },
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "'10100011001'"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# prompt: convert 1305 into binary\n",
-    "from numpy import binary_repr\n",
-    "binary_repr(1305)\n"
+    "np.binary_repr(1305)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "Kqjf-LBG3L4G"
-   },
+   "metadata": {},
    "source": [
-    "which we can check:\n",
-    "\n",
-    "$101000011001_2 = 1 \\times 2^0 + 0 \\times 2^1 + ... + 1 \\times 2^3 + 1 \\times 2^4+... + 1 \\times 2^8 + 0 \\times 2^{9} + 1 \\times 2^{10}$\n",
-    "$=1305_{10}$"
+    "which we can check:",
+    "$10100011001_2 = 1 \\times 2^0 + 0 \\times 2^1 + ... + 1 \\times 2^3 + 1 \\times 2^4+... + 1 \\times 2^8 + 0 \\times 2^{9} + 1 \\times 2^{10} = 1305_{10}$"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "V0I9zN6x1CdI"
-   },
+   "metadata": {},
    "source": [
-    "We can also use a decimal point with binary.\n",
-    "\n",
+    "We can also use a decimal point with binary.",
     "$54.75_{10} = 5\\times 10^{-2} + 7\\times 10^{-1} + 4 \\times 10^{0} + 5 \\times 10^{1}$"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
-   "metadata": {
-    "id": "NVL-x7081nFc"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "110110.11\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# prompt: express 54.75 in binary\n",
-    "\n",
-    "from numpy import binary_repr\n",
-    "\n",
-    "def decimal_to_binary(number):\n",
-    "  # Convert the integer part to binary\n",
-    "  integer_part = binary_repr(int(number))\n",
-    "\n",
-    "  # Convert the fractional part to binary\n",
-    "  fractional_part = number - int(number)\n",
-    "  binary_fractional_part = \"\"\n",
-    "  for i in range(20):\n",
-    "      fractional_part *= 2\n",
-    "      if fractional_part >= 1:\n",
-    "          binary_fractional_part += \"1\"\n",
-    "          fractional_part -= 1\n",
-    "      else:\n",
-    "          binary_fractional_part += \"0\"\n",
-    "      if fractional_part == 0:\n",
-    "          break\n",
-    "\n",
-    "# Combine the integer and fractional parts\n",
-    "  binary_representation = integer_part + \".\" + binary_fractional_part\n",
-    "\n",
-    "  print(binary_representation)\n",
-    "\n",
+    "def decimal_to_binary(number):",
+    "  # Convert the integer part to binary",
+    "  integer_part = np.binary_repr(int(number))",
+    "  # Convert the fractional part to binary",
+    "  fractional_part = number - int(number)",
+    "  binary_fractional_part = \"\"",
+    "  for i in range(20):",
+    "      fractional_part *= 2",
+    "      if fractional_part >= 1:",
+    "          binary_fractional_part += \"1\"",
+    "          fractional_part -= 1",
+    "      else:",
+    "          binary_fractional_part += \"0\"",
+    "      if fractional_part == 0:",
+    "          break",
+    "  # Combine the integer and fractional parts",
+    "  binary_representation = integer_part + \".\" + binary_fractional_part",
+    "  print(binary_representation)",
     "decimal_to_binary(54.75)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "ymdmAKaX1yN0"
-   },
+   "metadata": {},
    "source": [
-    "Check:\n",
+    "Check:",
     "$1 \\times 2^{-2} + 1 \\times 2^{-1} + 0 \\times 2^{0} + 1 \\times 2^{1} + 1 \\times 2^{2} + 0 \\times 2^{3} + 1 \\times 2^{4} + 1 \\times 2^{5} = 54.75_{10}$"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "W0WTSynd2ejq"
-   },
+   "metadata": {},
    "source": [
     "#### Example Convert 0.1 to binary"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
-   "metadata": {
-    "id": "hpxKHHFS2jby"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.00011001100110011001\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "decimal_to_binary(0.1)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "ASUuzIZQ3CxH"
-   },
+   "metadata": {},
    "source": [
     "The binary representation of 0.1 is a repeating number!"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "b7bmD7aH4agv"
-   },
+   "metadata": {},
    "source": [
     "## Precision"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "ymtlNqrX4gm_"
-   },
+   "metadata": {},
    "source": [
-    "Computers use a standard data unit, called a *word*. The number of bits in each word is called the *precision* and is, by IEEE convention, in increments of 32:\n",
-    "\n",
-    "Precision |  # bits\n",
-    "------|-------\n",
-    "single | 32\n",
-    "double | 64\n",
-    "quad   | 128\n",
-    "\n",
-    "For comparison, the previous number 10100011001 takes 11 bits.\n",
-    "\n",
-    "The most common precision in modern computing, and the standard in python3, is double precision. Quad precision is occasionally accessible for precise calculation.\n"
+    "Computers use a standard data unit, called a *word*. The number of bits in each word is called the *precision* and is, by IEEE convention, in increments of 32:",
+    "| Precision | # bits |",
+    "|---|---|",
+    "| single | 32 |",
+    "| double | 64 |",
+    "| quad   | 128 |",
+    "For comparison, the previous number 10100011001 takes 11 bits.",
+    "The most common precision in modern computing, and the standard in python3, is double precision. Quad precision is occasionally accessible for precise calculation."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "hFcxMhk14ljU"
-   },
+   "metadata": {},
    "source": [
     "## Integers"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "nLHlkRV04pnp"
-   },
+   "metadata": {},
    "source": [
-    "Integers are a fundamental data type if you don't need fractions, and **do not suffer from roundoff error**! However, since they have a finite number of digits (bits) their size is limited.\n",
-    "\n",
-    "The range of values an integer can store is $ 2^{bits}$.\n",
-    "Integers are signed, so we must include if the number is +'ve or -'ve. Furthermore, there is a redundancy where -0 = +0, leading to the range of -'ves being larger than that of +'ve.\n",
-    "\n",
-    "The min and max numbers an integer can represent is therefore:\n",
-    "\n",
-    "$min = -2^{bits-1}$\n",
-    "\n",
-    "$max = 2^{bits-1} -1$\n",
-    "\n",
-    "> You may be tempted to use a bit to represent the sign. This is not modern practice for integers, which instead use a method called *Two's complement*.  "
+    "Integers are a fundamental data type if you don't need fractions, and **do not suffer from roundoff error**! However, since they have a finite number of digits (bits) their size is limited.",
+    "The range of values an integer can store is $2^{bits}$.",
+    "Integers are signed, so we must include if the number is +'ve or -'ve. Furthermore, there is a redundancy where -0 = +0, leading to the range of -'ves being larger than that of +'ve.",
+    "The min and max numbers an integer can represent is therefore:",
+    "$min = -2^{bits-1}$",
+    "$max = 2^{bits-1} -1$",
+    "> You may be tempted to use a bit to represent the sign. This is not modern practice for integers, which instead use a method called *Two's complement*."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "GLsN3Iyp58o0"
-   },
+   "metadata": {},
    "source": [
     "#### Example: What is the largest integer a double precision variable can store?"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
-   "metadata": {
-    "id": "C4Deesot58N7"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "min  -9223372036854775808 \n",
-      "max   9223372036854775807\n",
-      "\n",
-      "Check with the built-in numpy examiner\n",
-      "Machine parameters for int64\n",
-      "---------------------------------------------------------------\n",
-      "min = -9223372036854775808\n",
-      "max = 9223372036854775807\n",
-      "---------------------------------------------------------------\n",
-      "\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "print('min ', -2**63, '\\nmax  ', 2**63-1)\n",
-    "\n",
-    "print('\\nCheck with the built-in numpy examiner')\n",
-    "import numpy as np\n",
-    "\n",
+    "print('min ', -2**63, '\\nmax  ', 2**63-1)",
+    "print('\\nCheck with the built-in numpy examiner')",
     "print(np.iinfo(np.int64))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "TKKSEV6leDcI"
-   },
+   "metadata": {},
    "source": [
     "#### Example 2: Let's break it!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "id": "x_d4sK9d_Mnw"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "4611686018427387904\n"
-     ]
-    },
-    {
-     "ename": "OverflowError",
-     "evalue": "int too big to convert",
-     "output_type": "error",
-     "traceback": [
-      "\u001b[31m---------------------------------------------------------------------------\u001b[39m",
-      "\u001b[31mOverflowError\u001b[39m                             Traceback (most recent call last)",
-      "\u001b[36mCell\u001b[39m\u001b[36m \u001b[39m\u001b[32mIn[11]\u001b[39m\u001b[32m, line 5\u001b[39m\n\u001b[32m      2\u001b[39m \u001b[38;5;28mprint\u001b[39m(np.int64(\u001b[32m2\u001b[39m**\u001b[32m62\u001b[39m))\n\u001b[32m      4\u001b[39m \u001b[38;5;66;03m#Overflow error\u001b[39;00m\n\u001b[32m----> \u001b[39m\u001b[32m5\u001b[39m \u001b[38;5;28mprint\u001b[39m(\u001b[43mnp\u001b[49m\u001b[43m.\u001b[49m\u001b[43mint64\u001b[49m\u001b[43m(\u001b[49m\u001b[32;43m2\u001b[39;49m\u001b[43m*\u001b[49m\u001b[43m*\u001b[49m\u001b[32;43m63\u001b[39;49m\u001b[43m)\u001b[49m)\n",
-      "\u001b[31mOverflowError\u001b[39m: int too big to convert"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# Works\n",
-    "print(np.int64(2**62))\n",
-    "\n",
-    "#Overflow error\n",
-    "print(np.int64(2**63))"
+    "# Works",
+    "print(np.int64(2**62))",
+    "#Overflow error",
+    "try:",
+    "    print(np.int64(2**63))",
+    "except OverflowError as e:",
+    "    print(e)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "1PwmE-OgfLhm"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "#Works\n",
-    "print(np.int64(1000000000000000000))\n",
-    "\n",
-    "#Overflow error\n",
-    "print(np.int64(10000000000000000000))"
+    "#Works",
+    "print(np.int64(1000000000000000000))",
+    "#Overflow error",
+    "try:",
+    "    print(np.int64(10000000000000000000))",
+    "except OverflowError as e:",
+    "    print(e)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "eAhJV_Fv-Jpp"
-   },
+   "metadata": {},
    "source": [
     "#Floating point numbers"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "EdsIoNZOe1hu"
-   },
+   "metadata": {},
    "source": [
-    "Writing a number like $10 000 000 000 000 000 000$ isn't really useful. It is much better to isolate the magnitude in units, or as an exponent:\n",
-    "\n",
+    "Writing a number like $10 000 000 000 000 000 000$ isn't really useful. It is much better to isolate the magnitude in units, or as an exponent:",
     "$10 000 000 000 000 000 000 = 10^{19}$"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "RvK2KPYReRTi"
-   },
+   "metadata": {},
    "source": [
     "## Floating point **Decimal** numbers (aka: Engineering notation)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "l3ynycWjEdeP"
-   },
+   "metadata": {},
    "source": [
-    "Remove leading zeros and *placeholder* trailing zeros using a *floating point* to separate the fractional part (mantissa / significand) from the order of magnitude (exponent).\n",
-    "\n",
-    "Engineering notation = $mantisa \\times 10^{exponent}$\n",
-    "\n",
-    "\n",
-    "Decimal  |  Engineering          | Mantissa       | Exponent\n",
-    "---------|------------------------|-----------------|--------\n",
-    "$265.73$ | $2.6573 \\times 10^2$  | 2.6573 | 2\n",
-    "$.0001$   | $1 \\times 10^{-4}$       | 1              | -4\n",
-    "$-0.0034123$ | $-3.4123 \\times 10^{-3}$ | -3.4123 | -3\n",
-    "$1500^*$   | $1.5 \\times 10^3$       | 1.5              | 3\n",
-    "\n",
-    "\\*only if the trailing zeros are not actually measured.\n",
-    "\n",
-    "Note:\n",
-    "1. The mantissa is a fraction, but if we *normalize* the fraction to have the decimal after the first digit, we can represent it as an integer.\n",
+    "Remove leading zeros and *placeholder* trailing zeros using a *floating point* to separate the fractional part (mantissa / significand) from the order of magnitude (exponent).",
+    "Engineering notation = $mantisa \\times 10^{exponent}$",
+    "| Decimal | Engineering | Mantissa | Exponent |",
+    "|---|---|---|---|",
+    "| $265.73$ | $2.6573 \\times 10^2$ | 2.6573 | 2 |",
+    "| $.0001$ | $1 \\times 10^{-4}$ | 1 | -4 |",
+    "| $-0.0034123$ | $-3.4123 \\times 10^{-3}$ | -3.4123 | -3 |",
+    "| $1500^*$ | $1.5 \\times 10^3$ | 1.5 | 3 |",
+    "\\*only if the trailing zeros are not actually measured.",
+    "Note:",
+    "1. The mantissa is a fraction, but if we *normalize* the fraction to have the decimal after the first digit, we can represent it as an integer.",
     "2. The exponent is the power of the number system *base*, in this case $10$."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
-   "metadata": {
-    "id": "Dy0QN85WhhIk"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "2.6573E2\n",
-      "1.0E-4\n",
-      "-3.4123E-3\n",
-      "1.5E3\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "'0'"
-      ]
-     },
-     "execution_count": 12,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# prompt: Convert a number to engineering notation\n",
-    "\n",
-    "def to_engineering_notation(number):\n",
-    "  if number == 0:\n",
-    "    return \"0\"\n",
-    "\n",
-    "  exponent = 0\n",
-    "  while abs(number) < 1:\n",
-    "    number *= 10\n",
-    "    exponent -= 1\n",
-    "  while abs(number) >= 10:\n",
-    "    number /= 10\n",
-    "    exponent += 1\n",
-    "\n",
-    "  print(f\"{number}E{exponent}\")\n",
-    "\n",
-    "to_engineering_notation(265.73)\n",
-    "to_engineering_notation(0.0001)\n",
-    "to_engineering_notation(-.0034123)\n",
-    "to_engineering_notation(1500)\n",
-    "to_engineering_notation(0)\n",
-    "\n",
+    "def to_engineering_notation(number):",
+    "  if number == 0:",
+    "    return \"0\"",
+    "  exponent = 0",
+    "  while abs(number) < 1:",
+    "    number *= 10",
+    "    exponent -= 1",
+    "  while abs(number) >= 10:",
+    "    number /= 10",
+    "    exponent += 1",
+    "  print(f\"{number}E{exponent}\")",
+    "to_engineering_notation(265.73)",
+    "to_engineering_notation(0.0001)",
+    "to_engineering_notation(-.0034123)",
+    "to_engineering_notation(1500)",
+    "to_engineering_notation(0)",
     "# You can also use Log10 to calculate this"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "XvZdxp-KgkUW"
-   },
+   "metadata": {},
    "source": [
     "## Floating point Binary numbers"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "GT0yFPtahBlx"
-   },
+   "metadata": {},
    "source": [
-    "The same technique can be applied to binary by using base 2:\n",
-    "\n",
-    "$mantisa \\times 2^{exponent}$\n",
-    "\n"
+    "The same technique can be applied to binary by using base 2:",
+    "$mantisa \\times 2^{exponent}$"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "D7d42wdnxJgj"
-   },
+   "metadata": {},
    "source": [
     "#### Example convert 54.75 into floating point binary"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "Hi5a58_txS4V"
-   },
+   "metadata": {},
    "source": [
-    "$54.75_{10} = 110110.11_2 $\n",
-    "\n",
-    "$= 1.1011011_2 \\times 2^5$\n",
-    "\n",
+    "$54.75_{10} = 110110.11_2 $",
+    "$= 1.1011011_2 \\times 2^5$",
     "$= 1.1011011_2 \\times 2^{101}$"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "9mXXYNtDl4Pg"
-   },
+   "metadata": {},
    "source": [
     "## Precision in floating point numbers"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "6xnJqD47l8qB"
-   },
+   "metadata": {},
    "source": [
-    "If the mantissa and exponent have infinite range, we can represent all numbers using floating point. However we are once again limited by the number of bits (precision). Now, the bits are divided into sign, mantissa, and exponent by convent: IEEE Standard for Floating-Point Arithmetic (IEEE 754):\n",
-    "\n",
-    "|Precision |# bits | Sign |Exponent |Mantissa |\n",
-    "|:------|:-----| :------------|:--------------------|:---------------------|\n",
-    "|Single| 1/8/23 | S            | EEEEEEEE          | FFFFFFFFFFFFFFFFFFFFFFF |\n",
-    "|Double| 1/11/52 | S            | EEEEEEEEEEE        | FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF |\n",
-    "|Quad | 1/15/112 | S            | EEEEEEEEEEEEEEE    | FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF |\n",
-    "\n"
+    "If the mantissa and exponent have infinite range, we can represent all numbers using floating point. However we are once again limited by the number of bits (precision). Now, the bits are divided into sign, mantissa, and exponent by convent: IEEE Standard for Floating-Point Arithmetic (IEEE 754):",
+    "|Precision |# bits | Sign |Exponent |Mantissa |",
+    "|:---|:---|:---|:---|:---|",
+    "|Single| 1/8/23 | S | EEEEEEEE | FFFFFFFFFFFFFFFFFFFFFFF |",
+    "|Double| 1/11/52 | S | EEEEEEEEEEE | FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF |",
+    "|Quad | 1/15/112 | S | EEEEEEEEEEEEEEE | FFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF |"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "P9GZex1vcyrb"
-   },
+   "metadata": {},
    "source": [
     "Note that the 'sign' bit is now here and is the sign of the number. The sign of the exponent is one of the bits in the 'exponent' block."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "WBEB1ozb3YI2"
-   },
+   "metadata": {},
    "source": [
     "The actual storage is a bit complicated, but the key for us is the finite precision of the mantissa."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "683nJz_U3kHS"
-   },
+   "metadata": {},
    "source": [
     "#### Example How is 0.1 actually stored?"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
-   "metadata": {
-    "id": "KVAQKK-N4bQ9"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.1000000000000000055511151231257827021181583404541015625\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
     "print(format(0.1, '.55f'))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
-   "metadata": {
-    "id": "KoaoV14l5of0"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "5.551115123125783e-17\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "error = 0.0000000000000000055511151231257827021181583404541015625\n",
-    "eps_r = error / 0.1\n",
+    "error = 0.1 - np.float64(0.1)",
+    "eps_r = error / 0.1",
     "print(eps_r)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "UxqjI1ZR6Cwk"
-   },
+   "metadata": {},
    "source": [
     "## Summary"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "BBxMgntD6J4O"
-   },
+   "metadata": {},
    "source": [
-    "In practice, we have to be careful when we mixing the order of terms. i.e. adding terms of different magnitude, or subtracting terms of slightly-varying magnitude.\n",
-    "\n",
+    "In practice, we have to be careful when we mixing the order of terms. i.e. adding terms of different magnitude, or subtracting terms of slightly-varying magnitude.",
     "We cannot count on the associative property:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
-   "metadata": {
-    "id": "0pQhs4jK6ZUT"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.0\n",
-      "1e-20\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "print(-1+(1+1e-20))\n",
+    "print(-1+(1+1e-20))",
     "print((-1+1)+1e-20)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "LUBUyP5n7YPq"
-   },
+   "metadata": {},
    "source": [
     "Beware of subtractive cancellation!"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
-   "metadata": {
-    "id": "X082gUU27dYp"
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "a = 1.23456788063049316406\n",
-      "b = 1.23456776142120361328\n",
-      "a - b = 1.1920929e-07\n"
-     ]
-    }
-   ],
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "# Define two nearly equal numbers\n",
-    "a = np.float32(1.23456789)\n",
-    "b = np.float32(1.23456780)\n",
-    "\n",
-    "# Perform subtraction\n",
-    "result = a - b\n",
-    "\n",
-    "# Print the results with higher precision\n",
-    "print(\"a =\", format(a, '.20f'))\n",
-    "print(\"b =\", format(b, '.20f'))\n",
-    "print(\"a - b =\", result)\n"
+    "# Define two nearly equal numbers",
+    "a = np.float32(1.23456789)",
+    "b = np.float32(1.23456780)",
+    "# Perform subtraction",
+    "result = a - b",
+    "# Print the results with higher precision",
+    "print(\"a =\", format(a, '.20f'))",
+    "print(\"b =\", format(b, '.20f'))",
+    "print(\"a - b =\", result)"
    ]
   }
  ],
  "metadata": {
-  "colab": {
-   "authorship_tag": "ABX9TyPXFp+TMMlThylH0c6C9J0/",
-   "include_colab_link": true,
-   "provenance": []
-  },
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"

--- a/Book/Chapters/Roundoff error/Roundoff error.ipynb
+++ b/Book/Chapters/Roundoff error/Roundoff error.ipynb
@@ -2,18 +2,23 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "wW4KU3zHwz10"
-   },
+   "metadata": {},
    "source": [
     "# Round-off Error"
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np"
+   ]
+  },
+  {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "MlhxbG0Hw4XC"
-   },
+   "metadata": {},
    "source": [
     "Round-off errors are possible whenever you have to write down a number. This is especially problematic for irrational numbers, but also true for rationals!"
    ]
@@ -21,64 +26,45 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "M1mR8YfDwuj0"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from numpy import pi, e, sqrt, binary_repr\n",
-    "print(pi, e, 1/3, sqrt(2))"
+    "print(np.pi, np.e, 1/3, np.sqrt(2))"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "kGVztDGlx-Ag"
-   },
+   "metadata": {},
    "source": [
-    "The problem is that we can only write down a finite number of digits before we get tired. So we round the last digit or chop it.\n",
-    "\n",
+    "The problem is that we can only write down a finite number of digits before we get tired. So we round the last digit or chop it.",
     "This error is inherant to *finite precision numerics*, not necessarily computations. The problem is that if computations include millions of calculations, these little mistakes can add up."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "_-wCuljO1yyn"
-   },
+   "metadata": {},
    "source": [
-    "\n",
-    "\n",
-    "> The average human is capable of around 1 mistake per second, but computers are capable of millions of mistakes a second!\n"
+    "> The average human is capable of around 1 mistake per second, but computers are capable of millions of mistakes a second!"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "QhDRwyHUB0FK"
-   },
+   "metadata": {},
    "source": [
-    "NB: If we could use infinite digits, or represent numbers symbolically (e.g. 1/3, $\\pi$, $\\sqrt 2$), this wouldn't be an issue. This is why tools like Mathematica, Maple, or the sympy module, don't evaluate anything until they have too.\n",
-    "\n",
+    "NB: If we could use infinite digits, or represent numbers symbolically (e.g. 1/3, $\\pi$, $\\sqrt 2$), this wouldn't be an issue. This is why tools like Mathematica, Maple, or the sympy module, don't evaluate anything until they have too.\\n",
+    "\\n",
     "Q: What are the pros and cons of keeping symbols?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "jVt1MCyCa5WS"
-   },
+   "metadata": {},
    "source": [
     "The impact of roundoff error is related to the precision (the number of digits we write down), and the way (base) we write numbers in."
    ]
   }
  ],
  "metadata": {
-  "colab": {
-   "authorship_tag": "ABX9TyPXFp+TMMlThylH0c6C9J0/",
-   "include_colab_link": true,
-   "provenance": []
-  },
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"

--- a/Book/Chapters/Roundoff error/True_and_approximate_error.ipynb
+++ b/Book/Chapters/Roundoff error/True_and_approximate_error.ipynb
@@ -2,11 +2,19 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "EnTndpiTR2qc"
-   },
+   "metadata": {},
    "source": [
-    "# Quantifying error\n"
+    "# Quantifying error"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np",
+    "import matplotlib.pyplot as plt"
    ]
   },
   {
@@ -18,106 +26,82 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "1rhnxoJMspU9"
-   },
+   "metadata": {},
    "source": [
-    "The difference between the true answer and an approximate answer is called the True Absolute Error:\n",
-    "\n",
-    "$E_t = |True - Approx| $\n",
-    "\n",
+    "The difference between the true answer and an approximate answer is called the True Absolute Error:",
+    "$E_t = |True - Approx|$",
     "Only really useful when the *true* value is known."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "8Vsxg3YE3DBb"
-   },
+   "metadata": {},
    "source": [
-    "#### Example: What is the derivative of $sin(x)$ at $x=0$?\n"
+    "#### Example: What is the derivative of $sin(x)$ at $x=0$?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "9MRAXK-MaDgb"
-   },
+   "metadata": {},
    "source": [
-    "Recall: $\\frac{d sin (x)}{dx} = lim_{\\Delta x->0} \\frac{sin(x+\\Delta x)-sin(x)}{\\Delta x}$"
+    "Recall: $\\frac{d\\sin(x)}{dx} = \\lim_{\\Delta x\\to 0} \\frac{\\sin(x+\\Delta x)-\\sin(x)}{\\Delta x}$"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "W_bTUPdqZ-Zb"
-   },
+   "metadata": {},
    "source": [
-    "True: $\\frac{d sin (x)}{dx} = cos(x)$"
+    "True: $\\frac{d\\sin(x)}{dx} = \\cos(x)$"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "9rxp6AA4Vlxi"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from numpy import cos, sin, abs\n",
-    "value_true = cos(0)\n",
-    "print(value_true) "
+    "value_true = np.cos(0)",
+    "print(value_true)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "UqYf9B99WEpl"
-   },
+   "metadata": {},
    "source": [
-    "Define a function (for later use) approx which takes a parameter, $\\Delta x$:\n",
-    "\n",
-    "$approx(\\Delta x) = \\frac{sin(x+\\Delta x)-sin(x)}{\\Delta x}$  "
+    "Define a function (for later use) approx which takes a parameter, $\\Delta x$:",
+    "$approx(\\Delta x) = \\frac{\\sin(x+\\Delta x)-\\sin(x)}{\\Delta x}$"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "cTnZjb4JVvcH"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "def approx(delta_x):\n",
-    "    return (sin(0+delta_x)-sin(0))/delta_x"
+    "def approx(delta_x):",
+    "    return (np.sin(0+delta_x)-np.sin(0))/delta_x"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "cd0EzJC5aOoq"
-   },
+   "metadata": {},
    "source": [
-    "For  $\\Delta x = .1$,"
+    "For $\\Delta x = .1$,"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "c0K2j3rpYwAN"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "value_approx = approx(delta_x = .1)\n",
+    "value_approx = approx(delta_x = .1)",
     "print(value_approx)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "eY4Odz5lZXVo"
-   },
+   "metadata": {},
    "source": [
     "The true absolute error is therefore,"
    ]
@@ -125,55 +109,36 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "Nbz_5-FAYyee"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "E_t = abs(value_true - value_approx)\n",
+    "E_t = np.abs(value_true - value_approx)",
     "print(E_t)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "tfbf3wcBah62"
-   },
+   "metadata": {},
    "source": [
-    "\n",
-    "\n",
-    "---\n",
-    "\n",
-    "\n",
     "## True relative error"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "DXIbm24Td5ZC"
-   },
+   "metadata": {},
    "source": [
-    "Often the absolute error is not so useful since it doesn't consider the magnitude of the value.\n",
-    "\n",
-    "E.g. GPS has an error of about ~1m. Is that important for calculating distance for a long road trip? What about a self-driving the car?\n",
-    "\n",
-    "Also note that absolute error has units which complicates generalization.\n",
-    "\n",
-    "The true relative error is defined as,\n",
-    "\n",
-    "$\\epsilon_t = \\frac{E_t}{True}$\n",
-    "\n",
-    "or as a percent,\n",
-    "\n",
+    "Often the absolute error is not so useful since it doesn't consider the magnitude of the value.",
+    "E.g. GPS has an error of about ~1m. Is that important for calculating distance for a long road trip? What about a self-driving the car?",
+    "Also note that absolute error has units which complicates generalization.",
+    "The true relative error is defined as,",
+    "$\\epsilon_t = \\frac{E_t}{True}$",
+    "or as a percent,",
     "$\\frac{E_t}{True} \\times 100 \\%$"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "0jqVDwQgd8-q"
-   },
+   "metadata": {},
    "source": [
     "#### Example: What is the relative error from the previous calculation?"
    ]
@@ -181,140 +146,99 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "s8IWAtc7cv5q"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "eps_t = E_t/value_true\n",
+    "eps_t = E_t/value_true",
     "print(eps_t)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "eujIzIHVc9t2"
-   },
+   "metadata": {},
    "source": [
-    "\n",
-    "\n",
-    "---\n",
-    "\n",
-    "\n",
     "## Approximate absolute and relative error"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "vrMKrL3Gsa96"
-   },
+   "metadata": {},
    "source": [
-    "What if we don't have the true value?\n",
-    "\n",
-    "Numerical methods typically have a tunable parameter that controls accuracy (viz. $\\Delta x$ above). We can estimate the error for sequential approximations, using the *better* approximation in place of the *True* one.\n",
-    "\n",
-    "$E_a = |Better\\ approx - approx|$\n",
-    "\n",
+    "What if we don't have the true value?",
+    "Numerical methods typically have a tunable parameter that controls accuracy (viz. $\\Delta x$ above). We can estimate the error for sequential approximations, using the *better* approximation in place of the *True* one.",
+    "$E_a = |Better\\ approx - approx|$",
     "$\\epsilon_a = \\frac{E_a}{Better\\ approx}$"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "DYhYz_GpfxHe"
-   },
+   "metadata": {},
    "source": [
-    "#### Example: Use smaller step sizes to find the approximate error and fracitonal error.\n"
+    "#### Example: Use smaller step sizes to find the approximate error and fracitonal error."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "3-SoANg6cyY3"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "E_a = abs(approx(.01) - approx(.1))\n",
+    "E_a = np.abs(approx(.01) - approx(.1))",
     "print(E_a)"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "dKw_EPuWgDkg"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "epsilon_a = E_a/approx(.01)\n",
+    "epsilon_a = E_a/approx(.01)",
     "print(epsilon_a)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "cvt-RO-ccczc"
-   },
+   "metadata": {},
    "source": [
-    "\n",
-    "\n",
-    "---\n",
-    "\n",
     "## Tolerance"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "HvLqcOPIbCVY"
-   },
+   "metadata": {},
    "source": [
-    "Since we don't know the true answer, we can never say that we have reached it. What we can say is that the answer *isn't getting any better*.\n",
-    "\n",
-    "Programmatically, we say that the error / fractional error has crossed a *tolerance*.\n",
-    "\n",
-    "Define:\n",
-    "\n",
-    "The absolute tolerance, $Tol_a$, is the threshold past which the absolute error is *small enough*.\n",
-    "\n",
-    "The relative tolerance, $Tol_r$, is the threshold past which the relative error is *small enough*.\n"
+    "Since we don't know the true answer, we can never say that we have reached it. What we can say is that the answer *isn't getting any better*.",
+    "Programmatically, we say that the error / fractional error has crossed a *tolerance*.",
+    "Define:",
+    "The absolute tolerance, $Tol_a$, is the threshold past which the absolute error is *small enough*.",
+    "The relative tolerance, $Tol_r$, is the threshold past which the relative error is *small enough*."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "0B4-vqMQcvV4"
-   },
+   "metadata": {},
    "source": [
     "## Pseudo code concept"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "NH9cqjWvc4wl"
-   },
+   "metadata": {},
    "source": [
-    "```\n",
-    "Run an algorithm for a given parameter\n",
-    "loop:\n",
-    "  reduce parameter\n",
-    "  run algorithm\n",
-    "  Calculate error and relative error\n",
-    "  Exit when tolerance is met\n",
-    "```\n",
-    "\n",
-    "\n",
-    "\n"
+    "```",
+    "Run an algorithm for a given parameter",
+    "loop:",
+    "  reduce parameter",
+    "  run algorithm",
+    "  Calculate error and relative error",
+    "  Exit when tolerance is met",
+    "```"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "VGFcCdcZqv08"
-   },
+   "metadata": {},
    "source": [
     "#### Example: Lets explore $E_a$ and $\\epsilon_a$ as a function of $\\Delta x$:"
    ]
@@ -322,68 +246,42 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "ydnylX8UeB3n"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# prompt: Plot E_a and epsilon_a vs delta_x for decending values of delta_x to 1e-10 on a log-log with markers\n",
-    "\n",
-    "import matplotlib.pyplot as plt\n",
-    "import numpy as np\n",
-    "\n",
-    "delta_x = np.logspace(0,-10,11)\n",
-    "E_a = np.zeros(delta_x.size)\n",
-    "epsilon_a = np.zeros(delta_x.size)\n",
-    "\n",
-    "for i, dx in enumerate(delta_x):\n",
-    "  E_a[i] = approx(dx/10) - approx(dx)\n",
-    "  epsilon_a[i] = E_a[i]/approx(dx/10)\n",
-    "\n",
-    "plt.loglog(delta_x, E_a, marker='o', label='$E_a$')\n",
-    "plt.loglog(delta_x, epsilon_a, marker='s', label='$\\epsilon_a$')\n",
-    "plt.xlabel('$\\Delta x$')\n",
-    "plt.ylabel('Error')\n",
-    "plt.legend()\n",
-    "plt.show()\n"
+    "delta_x = np.logspace(0,-10,11)",
+    "E_a = np.zeros(delta_x.size)",
+    "epsilon_a = np.zeros(delta_x.size)",
+    "for i, dx in enumerate(delta_x):",
+    "  E_a[i] = approx(dx/10) - approx(dx)",
+    "  epsilon_a[i] = E_a[i]/approx(dx/10)",
+    "plt.loglog(delta_x, E_a, marker='o', label='$E_a$')",
+    "plt.loglog(delta_x, epsilon_a, marker='s', label='$\\epsilon_a$')",
+    "plt.xlabel('$\\Delta x$')",
+    "plt.ylabel('Error')",
+    "plt.legend()",
+    "plt.show()"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "CEnO4Fzvg77t"
-   },
+   "metadata": {},
    "source": [
-    "Note:\n",
-    "\n",
-    "\n",
-    "*   The two errors overlap. Why?\n",
-    "*   The plot is a straight line. What does this mean?\n",
-    "*   There is a precipitous drop-off at $10^{-7}$. What is that?"
+    "Note:",
+    "* The two errors overlap. Why?",
+    "* The plot is a straight line. What does this mean?",
+    "* There is a precipitous drop-off at $10^{-7}$. What is that?"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "X8k50VLehixn"
-   },
+   "metadata": {},
    "source": [
     "THESE QUESTIONS AND MORE IN THE NEXT EXCITING EPISODE OF NUMERICAL METHODS FOR ENGINEERING!"
    ]
   }
  ],
  "metadata": {
-  "colab": {
-   "collapsed_sections": [
-    "EnTndpiTR2qc",
-    "8Vsxg3YE3DBb",
-    "tfbf3wcBah62",
-    "0jqVDwQgd8-q",
-    "eujIzIHVc9t2",
-    "DYhYz_GpfxHe"
-   ],
-   "provenance": []
-  },
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"

--- a/Book/Chapters/Roundoff error/Truncation_error.ipynb
+++ b/Book/Chapters/Roundoff error/Truncation_error.ipynb
@@ -2,182 +2,135 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "wW4KU3zHwz10"
-   },
+   "metadata": {},
    "source": [
     "# Truncation error"
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {
-    "id": "MlhxbG0Hw4XC"
-   },
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
    "source": [
-    "Truncation error occurs when we *approximate* a mathematical function.\n"
+    "import numpy as np",
+    "import math"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "XM91306CL5Ne"
-   },
+   "metadata": {},
+   "source": [
+    "Truncation error occurs when we *approximate* a mathematical function."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": [
     "## Taylor series"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "8zpo33tlL8U2"
-   },
+   "metadata": {},
    "source": [
-    "Recall the *EVER SO USEFUL* Taylor series:\n",
-    "\n",
-    "$f(x+\\Delta x) = f(x) + f'(x) \\Delta x + f''(x) \\frac{\\Delta x ^2}{2} + f'''(x) \\frac{\\Delta x ^3}{6} + ...$\n",
-    "\n",
-    "$= \\sum_{n=0}^{\\infty} \\frac{f^{(n)}(x)}{n!} \\Delta x ^n$\n",
-    "\n",
+    "Recall the *EVER SO USEFUL* Taylor series:",
+    "$f(x+\\Delta x) = f(x) + f'(x) \\Delta x + f''(x) \\frac{\\Delta x^2}{2} + f'''(x) \\frac{\\Delta x^3}{6} + ...$",
+    "$= \\sum_{n=0}^{\\infty} \\frac{f^{(n)}(x)}{n!} \\Delta x^n$",
     "but this is not useful unless we have an infinite amount of time and resources."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "B123-THhPHbb"
-   },
+   "metadata": {},
    "source": [
-    "If $\\Delta x$ is *small*, $\\Delta x ^2$ is smaller, and $\\Delta x ^3$ smaller still. In fact, as long as $f(x)$ is *well behaved* (loosely defined as continuous, smooth, differentiable, not infinite, etc) the derivatives don't explode exponentially and the rightmost terms get very small.\n",
-    "\n",
-    "So let's *truncate* the series and only keep the first $k$ terms:\n",
-    "\n",
-    "$f(x+\\Delta x) = f(x) + f'(x) \\Delta x + f''(x) \\frac{\\Delta x ^2}{2} + E_k $\n",
-    "\n",
-    "where\n",
-    "\n",
-    "$E_k = \\sum_{n=k}^{\\infty} \\frac{f^{(n)}(x)}{n!} \\Delta x ^n$\n",
-    "\n",
+    "If $\\Delta x$ is *small*, $\\Delta x^2$ is smaller, and $\\Delta x^3$ smaller still. In fact, as long as $f(x)$ is *well behaved* (loosely defined as continuous, smooth, differentiable, not infinite, etc) the derivatives don't explode exponentially and the rightmost terms get very small.",
+    "So let's *truncate* the series and only keep the first $k$ terms:",
+    "$f(x+\\Delta x) = f(x) + f'(x) \\Delta x + f''(x) \\frac{\\Delta x^2}{2} + E_k$",
+    "where",
+    "$E_k = \\sum_{n=k}^{\\infty} \\frac{f^{(n)}(x)}{n!} \\Delta x^n$",
     "is the **truncation error**."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "f0bRhvoVRL5R"
-   },
+   "metadata": {},
    "source": [
-    "This quantity is akin to a True Error in that if we knew what $E_k$ was exactly, we would have the true function $f$!\n",
-    "\n",
-    "It is more useful to define the *order* of the error. Noting that the leading term is $\\propto \\Delta x ^k$, we would say:\n",
-    "\n",
-    "$f(x_0+\\Delta x) \\approx f(x_0) + f'(x_0) \\Delta x + f''(x_0) \\frac{\\Delta x ^2}{2} + 𝒪(\\Delta x ^3)$\n",
-    "\n",
-    "or that this is a *third* order approximation.\n",
-    "\n",
-    "This is a useful statement, since it indicates the payoff for tuning the numerical parameters. In this case, halving the step size halves the error.  "
+    "This quantity is akin to a True Error in that if we knew what $E_k$ was exactly, we would have the true function $f$!",
+    "It is more useful to define the *order* of the error. Noting that the leading term is $\\propto \\Delta x^k$, we would say:",
+    "$f(x_0+\\Delta x) \\approx f(x_0) + f'(x_0) \\Delta x + f''(x_0) \\frac{\\Delta x^2}{2} + \\mathcal{O}(\\Delta x^3)$",
+    "or that this is a *third* order approximation.",
+    "This is a useful statement, since it indicates the payoff for tuning the numerical parameters. In this case, halving the step size halves the error."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "QcHnOPUiT6Bw"
-   },
+   "metadata": {},
    "source": [
     "#### Example: Find the order of approximate derivative we calculated previously (known as the *forward* difference)."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "kfpBqJI5UGL8"
-   },
+   "metadata": {},
    "source": [
-    "$f'(x) \\approx \\frac{f(x+\\Delta x) - f(x)}{\\Delta x}$\n",
-    "\n",
-    "We can substitute the Taylor series for $f(x+\\Delta x)$\n",
-    "\n",
-    "$f'(x) \\approx \\frac{f(x) + f'(x_0) \\Delta x + f''(x_0) \\frac{\\Delta x ^2}{2} ... - f(x)}{\\Delta x}$\n",
-    "\n",
-    "$\\approx \\frac{f'(x_0) \\Delta x + f''(x_0) \\frac{\\Delta x ^2}{2} ...}{\\Delta x}$\n",
-    "\n",
-    "$\\approx f'(x_0) + f''(x_0) \\frac{\\Delta x}{2} ...$\n",
-    "\n",
-    "$\\approx f'(x_0) + f''(x_0) \\frac{\\Delta x}{2} ...$\n",
-    "\n",
-    "$\\approx f'(x_0) + 𝒪(\\Delta x)$\n",
-    "\n",
+    "$f'(x) \\approx \\frac{f(x+\\Delta x) - f(x)}{\\Delta x}$",
+    "We can substitute the Taylor series for $f(x+\\Delta x)$",
+    "$f'(x) \\approx \\frac{f(x) + f'(x_0) \\Delta x + f''(x_0) \\frac{\\Delta x^2}{2} ... - f(x)}{\\Delta x}$",
+    "$\\approx \\frac{f'(x_0) \\Delta x + f''(x_0) \\frac{\\Delta x^2}{2} ...}{\\Delta x}$",
+    "$\\approx f'(x_0) + f''(x_0) \\frac{\\Delta x}{2} ...$",
+    "$\\approx f'(x_0) + \\mathcal{O}(\\Delta x)$",
     "Therefore this approximation, call the *forward difference* is a first order algorithm."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "BGih8nflWfp-"
-   },
+   "metadata": {},
    "source": [
-    "### Example 2: Find the order of approximatino of the central difference formula,\n",
+    "### Example 2: Find the order of approximatino of the central difference formula,",
     "$f'(x) \\approx \\frac{f(x+\\Delta x) - f(x-\\Delta x)}{2 \\Delta x}$"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "d_BxUma_WMFr"
-   },
+   "metadata": {},
    "source": [
-    "Substituting the (3rd order) Taylor series for $f(x+\\Delta x)$ and $f(x+[-\\Delta x])$\n",
-    "\n",
-    "$f'(x) \\approx \\frac{f(x) + f'(x) \\Delta x + f''(x) \\frac{\\Delta x ^2}{2} + f'''(x_0) \\frac{\\Delta x ^3}{6} ... - [f(x) + f'(x) [-\\Delta x] + f''(x) \\frac{-\\Delta x ^2}{2} + f'''(x_0) \\frac{-\\Delta x ^3}{6}...]}{2 \\Delta x}$\n",
-    "\n",
-    "$\\approx \\frac{f(x) + f'(x) \\Delta x + f''(x) \\frac{\\Delta x ^2}{2} + f'''(x_0) \\frac{\\Delta x ^3}{6} ... - f(x) + f'(x) \\Delta x - f''(x) \\frac{-\\Delta x ^2}{2} + f'''(x_0) \\frac{-\\Delta x ^3}{6}...}{2 \\Delta x}$\n",
-    "\n",
-    "$\\approx \\frac{2 f'(x) \\Delta x + 2 f'''(x_0) \\frac{\\Delta x ^3}{6} ...}{2 \\Delta x}$\n",
-    "\n",
-    "$\\approx f'(x) + f'''(x_0) \\frac{\\Delta x ^2}{6} ...$\n",
-    "\n",
-    "$\\approx f'(x) + 𝒪(\\Delta x ^2)$\n",
-    "\n",
-    "\n",
+    "Substituting the (3rd order) Taylor series for $f(x+\\Delta x)$ and $f(x+[-\\Delta x])$",
+    "$f'(x) \\approx \\frac{f(x) + f'(x) \\Delta x + f''(x) \\frac{\\Delta x^2}{2} + f'''(x_0) \\frac{\\Delta x^3}{6} ... - [f(x) + f'(x) [-\\Delta x] + f''(x) \\frac{-\\Delta x^2}{2} + f'''(x_0) \\frac{-\\Delta x^3}{6}...]}{2 \\Delta x}$",
+    "$\\approx \\frac{f(x) + f'(x) \\Delta x + f''(x) \\frac{\\Delta x^2}{2} + f'''(x_0) \\frac{\\Delta x^3}{6} ... - f(x) + f'(x) \\Delta x - f''(x) \\frac{-\\Delta x^2}{2} + f'''(x_0) \\frac{-\\Delta x^3}{6}...}{2 \\Delta x}$",
+    "$\\approx \\frac{2 f'(x) \\Delta x + 2 f'''(x_0) \\frac{\\Delta x^3}{6} ...}{2 \\Delta x}$",
+    "$\\approx f'(x) + f'''(x_0) \\frac{\\Delta x^2}{6} ...$",
+    "$\\approx f'(x) + \\mathcal{O}(\\Delta x^2)$",
     "Therefore, the central difference approximation is a second order algorithm (for the same number of function calls!). By halving the step size, the error is quartered!"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "P1_GJuO-tpUG"
-   },
+   "metadata": {},
    "source": [
     "## Common mathematical functions"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "eV094Wz2wmne"
-   },
+   "metadata": {},
    "source": [
-    "Computers are very good at addition / subtraction, multiplication / division, and exponentiation. How should we calculate other functions?\n",
-    "\n",
-    "Let's examine some Taylor expansions:\n",
-    "\n",
-    "| Function | Taylor Expansion                 |\n",
-    "|:---------------|:------------------------------------------------------------------|\n",
-    "| $\\sin(x) $ | $ x - \\frac{x^3}{3!} + \\frac{x^5}{5!} - \\frac{x^7}{7!} + \\cdots $ |\n",
-    "| $ \\cos(x) $ | $ 1 - \\frac{x^2}{2!} + \\frac{x^4}{4!} - \\frac{x^6}{6!} + \\cdots $ |\n",
-    "| $ \\exp(x) $ | $ 1 + x + \\frac{x^2}{2!} + \\frac{x^3}{3!} + \\frac{x^4}{4!} + \\cdots $ |\n",
-    "| $ \\ln(1+x) $ | $ x - \\frac{x^2}{2} + \\frac{x^3}{3} - \\frac{x^4}{4} + \\cdots $ |\n",
-    "\n",
-    "On the surface these look good, and in *infinite* precision they are globally convergent.\n",
-    "\n",
+    "Computers are very good at addition / subtraction, multiplication / division, and exponentiation. How should we calculate other functions?",
+    "Let's examine some Taylor expansions:",
+    "| Function | Taylor Expansion |",
+    "|:---|:---|",
+    "| $\\sin(x)$ | $ x - \\frac{x^3}{3!} + \\frac{x^5}{5!} - \\frac{x^7}{7!} + \\cdots $ |",
+    "| $ \\cos(x)$ | $ 1 - \\frac{x^2}{2!} + \\frac{x^4}{4!} - \\frac{x^6}{6!} + \\cdots $ |",
+    "| $ \\exp(x)$ | $ 1 + x + \\frac{x^2}{2!} + \\frac{x^3}{3!} + \\frac{x^4}{4!} + \\cdots $ |",
+    "| $ \\ln(1+x)$ | $ x - \\frac{x^2}{2} + \\frac{x^3}{3} - \\frac{x^4}{4} + \\cdots $ |",
+    "On the surface these look good, and in *infinite* precision they are globally convergent.",
     "But we are not in *infinite* precision."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "L-0Boej0mg4e"
-   },
+   "metadata": {},
    "source": [
     "#### Example: Examine the terms of $sin(x)$ for small x"
    ]
@@ -185,41 +138,31 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "XKxYc2m5o1pC"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "from numpy import pi, e, sqrt, binary_repr\n",
-    "import numpy as np\n",
-    "import math\n",
-    "\n",
-    "def taylor_series_sin(x, n_terms):\n",
-    "    \"\"\"\n",
-    "    Calculate the Taylor series expansion of sin(x) up to n_terms.\n",
-    "\n",
-    "    Parameters:\n",
-    "    x (float): The point at which to evaluate the Taylor series.\n",
-    "    n_terms (int): The number of terms to include in the expansion.\n",
-    "\n",
-    "    Returns:\n",
-    "    list: A list of terms in the Taylor series expansion.\n",
-    "    \"\"\"\n",
-    "    terms = []\n",
-    "    for n in range(n_terms):\n",
-    "        term = ((-1)**n * x**(2*n + 1)) / math.factorial(2*n + 1)\n",
-    "        terms.append(term)\n",
-    "    print(\"The terms are as follows:\")\n",
-    "    for i, term in enumerate(terms):\n",
-    "        print(f\"Term {i+1}: {term:.10f}\")\n",
+    "def taylor_series_sin(x, n_terms):",
+    "    \"\"\"",
+    "    Calculate the Taylor series expansion of sin(x) up to n_terms.",
+    "    Parameters:",
+    "    x (float): The point at which to evaluate the Taylor series.",
+    "    n_terms (int): The number of terms to include in the expansion.",
+    "    Returns:",
+    "    list: A list of terms in the Taylor series expansion.",
+    "    \"\"\"",
+    "    terms = []",
+    "    for n in range(n_terms):",
+    "        term = ((-1)**n * x**(2*n + 1)) / math.factorial(2*n + 1)",
+    "        terms.append(term)",
+    "    print(\"The terms are as follows:\")",
+    "    for i, term in enumerate(terms):",
+    "        print(f\"Term {i+1}: {term:.10f}\")",
     "    print(f\"Approximate sin({x}): {sum(terms):.10f}, and it should be {math.sin(x):.10f}\")"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "ymjLGoNrmzxZ"
-   },
+   "metadata": {},
    "source": [
     "For a small x:"
    ]
@@ -227,9 +170,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "j-TNnds0k8qe"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "taylor_series_sin(1, 10)"
@@ -237,20 +178,15 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "nak6AIcim9Te"
-   },
+   "metadata": {},
    "source": [
-    "NB: The terms are flipping signs (potential for roundoff error), but more importantly they are decresing.\n",
-    "\n",
+    "NB: The terms are flipping signs (potential for roundoff error), but more importantly they are decresing.",
     "-> No problem"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "jS8yAZ5ZnIt6"
-   },
+   "metadata": {},
    "source": [
     "#### Example: Examine the terms of  sin(x)  for large x"
    ]
@@ -258,9 +194,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "K1uyHPrTmyq7"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "taylor_series_sin(10, 10)"
@@ -268,9 +202,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "-6Z8scosnUqA"
-   },
+   "metadata": {},
    "source": [
     "Getting a bit funny..."
    ]
@@ -278,9 +210,7 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "DkStK5CRnSOS"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "taylor_series_sin(100, 10)"
@@ -288,75 +218,50 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "IoFKcbLynfVn"
-   },
+   "metadata": {},
    "source": [
     "Completely wrong."
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "oz4jXj5YpqgJ"
-   },
+   "metadata": {},
    "source": [
     "## Why you should use a package"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "p6e5Gk9ApyM2"
-   },
+   "metadata": {},
    "source": [
-    "In this case, the remedy is fairly simple, but if you are not careful, these function can behave very strangely. In practice, the means of calculation are very sophisticated for performance and stability, including other expansion techniques and sometimes even look-up tables.\n",
-    "\n",
+    "In this case, the remedy is fairly simple, but if you are not careful, these function can behave very strangely. In practice, the means of calculation are very sophisticated for performance and stability, including other expansion techniques and sometimes even look-up tables.",
     "This is why we use packages! :-)"
    ]
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "id": "omaRkDnMqySz"
-   },
+   "metadata": {},
    "source": [
-    "The Taylor expansion is still useful to consider limiting behaviour.\n",
-    "\n",
-    "For small $x$,\n",
-    "\n",
-    "$exp(x) \\approx 1+x$\n",
+    "The Taylor expansion is still useful to consider limiting behaviour.",
+    "For small $x$,",
+    "$exp(x) \\approx 1+x$",
     "which is subject to roundoff error. Therefore packages like numpy provide special functions like $expm1 = exp(x)-1$"
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "id": "sK8PJHgksbl2"
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
-    "# Poorer approximation\n",
-    "print(np.exp(1e-10) - 1)\n",
-    "\n",
-    "#Better approximation\n",
+    "# Poorer approximation",
+    "print(np.exp(1e-10) - 1)",
+    "#Better approximation",
     "print(np.expm1(1e-10))"
    ]
   }
  ],
  "metadata": {
-  "colab": {
-   "authorship_tag": "ABX9TyO0r8d/UNXYqnq6tn/+efDG",
-   "collapsed_sections": [
-    "XM91306CL5Ne",
-    "QcHnOPUiT6Bw",
-    "BGih8nflWfp-",
-    "P1_GJuO-tpUG"
-   ],
-   "include_colab_link": true,
-   "provenance": []
-  },
   "kernelspec": {
    "display_name": "Python 3",
    "name": "python3"

--- a/Book/index.md
+++ b/Book/index.md
@@ -1,30 +1,19 @@
-
 # Welcome
 
-This online textbook is associated with the course EngPhys 3NM4 at McMaster University. 
+This online textbook is associated with the course EngPhys 3NM4 at McMaster University.
 
-Decompose into simpler problems. 
+This book is an introduction to numerical methods. The main themes are:
 
-This is an introduction to the book. Below are the main sections:
+*   Decomposing complex problems into simpler ones.
+*   Boiling everything down to a simple task (e.g., solving a linear system of equations).
+*   Approximating functions as weighted sums of simpler functions (a linear basis).
+*   Expanding functions as Taylor series.
+*   Achieving higher order accuracy by:
+    *   approximating higher order derivatives.
+    *   cancelling over and under prediction by averaging.
 
-* Boil everything down to a simple task (linear system of equations)
-* Approximate functions as weighted sums of simpler functions (a linear basis)
-* Expand functions as Taylor series 
-* Achieve higher order accuracy by 
-* * approximating higher order derivatives.
-* * cancelling over and under prediction by averaging. 
-
-AI is fast. Use your head before the computer or it will run away with you! 
+A recurring theme is that AI is fast. Use your head before the computer or it will run away with you!
 
 [PDF of the full book](_static/book.pdf)
-
-[Pretrained notepadlm](https://notebooklm.google.com/notebook/31dca965-3ce5-42e2-b423-c04bd11bfc98)
-
-[Youtube channel with lectures](https://www.youtube.com/@McMaster_EngPhys3NM4)
-
-[NotepadLM 'Audio overview'](https://notebooklm.google.com/notebook/a1f51dab-a729-4dfb-b94b-965be763a7b1/audio)
-NB: The audio overview is AI generated from the notes. Although it is well grounded, it may still be incorrect.
-
-This resource is being developed in part through the [McMaster University Open Educational Resources grant](https://mi.mcmaster.ca/oer-grant).
 
 ![Meme](Meme.png)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-Webite: https://themintlab.github.io/ENGPYHS_3NM4/
+Webite: https://mwelland.github.io/ENGPYHS_3NM4/


### PR DESCRIPTION
This commit addresses several formatting issues in the welcome and round-off error chapters to ensure a consistent style across the textbook.

The following changes were made:
- Standardized Python imports in all notebooks to be at the top of the file.
- Removed all 'open in colab' badges and metadata.
- Corrected and improved LaTeX formatting for mathematical equations.
- Cleaned up markdown formatting, including removing extra newlines and fixing table layouts.
- Improved the overall readability of the welcome page.
- Added error handling for expected overflow errors in code cells to prevent notebook execution from crashing.